### PR TITLE
Add map for 'com.eface2face.iosrtc' --> 'cordova-plugin-iosrtc'

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,8 @@ var map = {
     'com.disusered.open' : 'cordova-open',
     'com.disusered.safe' : 'cordova-safe',
     'me.apla.cordova.app-preferences' : 'cordova-plugin-app-preferences',
-    'com.konotor.cordova' : 'cordova-plugin-konotor'
+    'com.konotor.cordova' : 'cordova-plugin-konotor',
+    'com.eface2face.iosrtc' : 'cordova-plugin-iosrtc'
 }
 
 module.exports.oldToNew = map;


### PR DESCRIPTION
I've just migrated [cordova-plugin-iosrtc](https://github.com/eface2face/cordova-plugin-iosrtc) to NPM and want to rename the old id 'com.eface2face.iosrtc' to just 'cordova-plugin-iosrtc'.
