### PR TITLE
replacing com.arcoirislabs.plugin.mqtt

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,8 @@ var map = {
     'com.chariotsolutions.nfc.plugin': 'phonegap-nfc',
     'com.samz.mixpanel': 'cordova-plugin-mixpanel',
     'de.appplant.cordova.common.RegisterUserNotificationSettings': 'cordova-plugin-registerusernotificationsettings',
-    'plugin.google.maps': 'cordova-plugin-googlemaps'
+    'plugin.google.maps': 'cordova-plugin-googlemaps',
+    'com.arcoirislabs.plugin.mqtt' : 'cordova-plugin-mqtt'
 };
 
 module.exports.oldToNew = map;


### PR DESCRIPTION
replacing com.arcoirislabs.plugin.mqtt by cordova-plugin-mqtt
