### PR TITLE
delete whitespace at begin of plugin-name cordova-plugin-fastrde-md5

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ var map = {
     'de.fastr.phonegap.plugins.downloader' : 'cordova-plugin-fastrde-downloader',
     'de.fastr.phonegap.plugins.injectView' : 'cordova-plugin-fastrde-injectview',
     'de.fastr.phonegap.plugins.CheckGPS' : 'cordova-plugin-fastrde-checkgps',
-    'de.fastr.phonegap.plugins.md5chksum' : ' cordova-plugin-fastrde-md5',
+    'de.fastr.phonegap.plugins.md5chksum' : 'cordova-plugin-fastrde-md5',
     'io.repro.cordova' : 'cordova-plugin-repro',
     're.notifica.cordova': 'cordova-plugin-notificare-push',
     'com.megster.cordova.ble': 'cordova-plugin-ble-central',


### PR DESCRIPTION
fixed a typo.
See https://github.com/fastrde/cordova-plugin-fastrde-downloader/issues/6 for details.
