### PR TITLE
Use SPDX-compatible license name

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "plugins"
   ],
   "author": "Steve Gill",
-  "license": "Apache version 2.0",
+  "license": "Apache-2.0",
   "devDependencies": {
     "tape": "^3.5.0"
   }


### PR DESCRIPTION
The proper string for the Apache version 2.0 license is "Apache-2.0".

See https://spdx.org/licenses/