### PR TITLE
Change license expression to use SPDX identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "plugins"
   ],
   "author": "Steve Gill",
-  "license": "Apache version 2.0",
+  "license": "Apache-2.0",
   "devDependencies": {
     "tape": "^3.5.0"
   }


### PR DESCRIPTION
This will set the package.json license value to match the Apache License 2.0 identifier from https://spdx.org/licenses. The change will allow easier identification of the license by automated auditing tools.

For some reason, license checking utilities (specifically [license-checker](https://github.com/davglass/license-checker))fail to identify the license and substitute the build status badge from the readme.

| **Before** | **After** |
| ---             | ---           |
|![Screen Shot 2019-05-07 at 6 47 32 PM](https://user-images.githubusercontent.com/869227/57337834-008e3c80-70f9-11e9-8cd6-8a5b879db22d.png)|![Screen Shot 2019-05-07 at 6 47 55 PM](https://user-images.githubusercontent.com/869227/57337844-07b54a80-70f9-11e9-8d4f-f5fb8cb21b18.png)|
